### PR TITLE
随机抽取回复开关

### DIFF
--- a/nonebot_plugin_autoreply/config.py
+++ b/nonebot_plugin_autoreply/config.py
@@ -23,6 +23,7 @@ class ReplyEntry(BaseModel):
         ignore_case: bool = True
         strip: bool = True
         allow_plaintext: bool = True
+        replies_random: bool = True
 
     class ReplyDict(TypedDict):
         type: str


### PR DESCRIPTION
大佬的插件挺实用的，可以方便地设置自动回复了
就是如果回复的内容需要固定的话，就出问题了
如特殊消息或链接一下面这种形式发出就不太行
[![例子](https://s1.ax1x.com/2023/02/12/pS5ACLj.png)](https://imgse.com/i/pS5ACLj)
所以要单独发出，这就不能随机了

代码没什么水平，因为是新手，如果有不对的地方，还请多多指教
大佬如果觉得代码不可取，就当我提了个想法吧！